### PR TITLE
fix-sending-session-cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ class CommentsController < ApplicationController
 end
 ```
 
+#### (optional) Disable session storage
+Most API's should not create sessions for each API request.
+This can be configured via the Devise `skip_session_storage` setting.
+
+```ruby
+# config/initializers/devise.rb
+config.skip_session_storage = [:http_auth] # this is the default devise config
+config.skip_session_storage << :doorkeeper # disable session storage for oauth requests
+```
+
 ## [ Contributing ](CONTRIBUTING.md)
 
 1. Fork it ( https://github.com/betterup/devise-doorkeeper/fork )

--- a/lib/devise/doorkeeper/version.rb
+++ b/lib/devise/doorkeeper/version.rb
@@ -1,5 +1,5 @@
 module Devise
   module Doorkeeper
-    VERSION = "1.0.0"
+    VERSION = '1.0.1'
   end
 end

--- a/lib/devise/strategies/doorkeeper.rb
+++ b/lib/devise/strategies/doorkeeper.rb
@@ -20,6 +20,22 @@ module Devise
         end
       end
 
+      # override base class implementation
+      # allow for Rails application to configure
+      # skipping session storage for doorkeeper requests
+      # see Devise skip_session_storage configuration
+      def authentication_type
+        :doorkeeper
+      end
+
+      # override base class implementation
+      # API requests should *not* reset the user's
+      # CSRF token which triggers rails to set the
+      # session_id key and send cookies to users
+      def clean_up_csrf?
+        false
+      end
+
       private
 
       def resource_from_token

--- a/spec/dummy/config/initializers/devise.rb
+++ b/spec/dummy/config/initializers/devise.rb
@@ -78,6 +78,7 @@ Devise.setup do |config|
   # may want to disable generating routes to Devise's sessions controller by
   # passing skip: :sessions to `devise_for` in your config/routes.rb
   config.skip_session_storage = [:http_auth]
+  config.skip_session_storage << :doorkeeper
 
   # By default, Devise cleans up the CSRF token on authentication to
   # avoid CSRF token fixation attacks. This means that, when using AJAX

--- a/spec/requests/oauth/bearer_tokens_spec.rb
+++ b/spec/requests/oauth/bearer_tokens_spec.rb
@@ -14,6 +14,9 @@ RSpec.describe 'OAuth bearer token requests', type: :request do
       get request_path, params, headers
     end
     it { expect(response.status).to eq 200 }
+    it 'does not send Set-Cookie headers' do
+      expect(response.headers).to_not include 'Set-Cookie'
+    end
   end
   context 'with expired access token' do
     with :access_token, expires_in: 0


### PR DESCRIPTION
### Changelog
Allow API requests without creating sessions.

Most API's should *not* allow using session cookies
for authentication.