### PR TITLE
error-response

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,25 @@ gem 'devise-doorkeeper'
 
 #### Update doorkeeper config
 Update your `config/initializers/doorkeeper.rb` to call
-`Devise::Doorkeeper.configure(self)`.
+`Devise::Doorkeeper.configure_doorkeeper(self)`.
 
 ```ruby
 # config/initializers/doorkeeper.rb
 Doorkeeper.configure do
-  Devise::Doorkeeper.configure(self)
+  Devise::Doorkeeper.configure_doorkeeper(self)
+
+  # extra configuration goes below
+end
+```
+
+#### Update devise config
+Update your `config/initializers/devise.rb` to call
+`Devise::Doorkeeper.configure_devise`.
+
+```ruby
+# config/initializers/devise.rb
+Devise.setup do |config|
+  Devise::Doorkeeper.configure_devise(config)
 
   # extra configuration goes below
 end

--- a/lib/devise/doorkeeper.rb
+++ b/lib/devise/doorkeeper.rb
@@ -3,7 +3,14 @@ require 'devise/strategies/doorkeeper'
 
 module Devise
   module Doorkeeper
-    def self.configure(base)
+    def self.configure_devise(config)
+      config.warden do |manager|
+        require 'devise/doorkeeper/doorkeeper_failure_app'
+        manager.failure_app = Devise::Doorkeeper::DoorkeeperFailureApp
+      end
+    end
+
+    def self.configure_doorkeeper(base)
       base.instance_eval do
         resource_owner_authenticator do
           current_user || warden.authenticate!(scope: :user)

--- a/lib/devise/doorkeeper/doorkeeper_failure_app.rb
+++ b/lib/devise/doorkeeper/doorkeeper_failure_app.rb
@@ -1,0 +1,25 @@
+require 'devise/failure_app'
+require 'devise/strategies/doorkeeper'
+
+module Devise
+  module Doorkeeper
+    class DoorkeeperFailureApp < ::Devise::FailureApp
+      def respond
+        if warden_message == Devise::Strategies::Doorkeeper::WARDEN_INVALID_TOKEN_MESSAGE
+          invalid_oauth_token
+        else
+          super
+        end
+      end
+
+      private
+
+      def invalid_oauth_token
+        error = ::Doorkeeper::OAuth::InvalidTokenResponse.new
+        headers.merge! error.headers
+        self.response_body = error.body.to_json
+        self.status        = error.status
+      end
+    end
+  end
+end

--- a/lib/devise/doorkeeper/version.rb
+++ b/lib/devise/doorkeeper/version.rb
@@ -1,5 +1,5 @@
 module Devise
   module Doorkeeper
-    VERSION = '1.0.1'
+    VERSION = '1.1.0'
   end
 end

--- a/lib/devise/strategies/doorkeeper.rb
+++ b/lib/devise/strategies/doorkeeper.rb
@@ -6,6 +6,8 @@ require 'devise/strategies/authenticatable'
 module Devise
   module Strategies
     class Doorkeeper < ::Devise::Strategies::Authenticatable
+      WARDEN_INVALID_TOKEN_MESSAGE = :invalid_token
+
       def valid?
         credentials = ::Doorkeeper::OAuth::Token.from_request(request, *access_token_methods)
         credentials.present?
@@ -46,7 +48,7 @@ module Devise
       end
 
       def invalid_token
-        fail!(:invalid_token)
+        fail!(WARDEN_INVALID_TOKEN_MESSAGE)
         throw :warden
       end
 

--- a/spec/dummy/config/initializers/devise.rb
+++ b/spec/dummy/config/initializers/devise.rb
@@ -1,6 +1,7 @@
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
+  Devise::Doorkeeper.configure_devise(config)
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.

--- a/spec/dummy/config/initializers/doorkeeper.rb
+++ b/spec/dummy/config/initializers/doorkeeper.rb
@@ -1,5 +1,5 @@
 Doorkeeper.configure do
-  Devise::Doorkeeper.configure(self)
+  Devise::Doorkeeper.configure_doorkeeper(self)
 
   # Change the ORM that doorkeeper will use.
   # Currently supported options are :active_record, :mongoid2, :mongoid3,
@@ -99,7 +99,7 @@ Doorkeeper.configure do
   # end
 
   # WWW-Authenticate Realm (default "Doorkeeper").
-  # realm "Doorkeeper"
+  realm 'DeviseDoorkeeperApp'
 
   # Allow dynamic query parameters (disabled by default)
   # Some applications require dynamic query parameters on their request_uri

--- a/spec/requests/oauth/bearer_tokens_spec.rb
+++ b/spec/requests/oauth/bearer_tokens_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe 'OAuth bearer token requests', type: :request do
       get request_path, params, headers
     end
     it { expect(response.status).to eq 401 }
+    it { expect(response.headers).to include('WWW-Authenticate' => 'Bearer realm="DeviseDoorkeeperApp", error="invalid_token", error_description="The access token is invalid"') }
   end
   context 'with revoked access token' do
     with :access_token, revoked_at: 1.year.ago


### PR DESCRIPTION
### Changelog
Add custom devise failure app for proper oauth responses.

See OAuth2 RFC for more information on expected header values
for requests:
http://self-issued.info/docs/draft-ietf-oauth-v2-bearer.html#authn-header

Changes:
* Add Devise::Doorkeeper.configure_devise method and docs
* Rename Devise::Doorkeeper.configure to
  Devise::Doorkeeper.configure_doorkeeper