### PR TITLE
fix failure headers

### DIFF
--- a/lib/devise/doorkeeper.rb
+++ b/lib/devise/doorkeeper.rb
@@ -1,15 +1,15 @@
 require 'devise/doorkeeper/version'
 require 'devise/strategies/doorkeeper'
+require 'devise/doorkeeper/doorkeeper_failure_app'
 
 module Devise
   module Doorkeeper
+    # configure devise to support doorkeeper error responses
+    # DEPRECATED: this is no longer used now that DoorkeeperFailureApp is auto-injected into the FailureApp
     def self.configure_devise(config)
-      config.warden do |manager|
-        require 'devise/doorkeeper/doorkeeper_failure_app'
-        manager.failure_app = Devise::Doorkeeper::DoorkeeperFailureApp
-      end
     end
 
+    # configure doorkeeper to use devise authentication
     def self.configure_doorkeeper(base)
       base.instance_eval do
         resource_owner_authenticator do

--- a/lib/devise/doorkeeper.rb
+++ b/lib/devise/doorkeeper.rb
@@ -5,8 +5,8 @@ require 'devise/doorkeeper/doorkeeper_failure_app'
 module Devise
   module Doorkeeper
     # configure devise to support doorkeeper error responses
-    # DEPRECATED: this is no longer used now that DoorkeeperFailureApp is auto-injected into the FailureApp
     def self.configure_devise(config)
+      Devise::FailureApp.prepend(Devise::Doorkeeper::DoorkeeperFailureApp)
     end
 
     # configure doorkeeper to use devise authentication

--- a/lib/devise/doorkeeper/doorkeeper_failure_app.rb
+++ b/lib/devise/doorkeeper/doorkeeper_failure_app.rb
@@ -1,4 +1,3 @@
-require 'devise/failure_app'
 require 'devise/strategies/doorkeeper'
 
 module Devise
@@ -27,4 +26,3 @@ module Devise
     end
   end
 end
-Devise::FailureApp.prepend(Devise::Doorkeeper::DoorkeeperFailureApp)

--- a/lib/devise/doorkeeper/version.rb
+++ b/lib/devise/doorkeeper/version.rb
@@ -1,5 +1,5 @@
 module Devise
   module Doorkeeper
-    VERSION = '1.1.1'
+    VERSION = '1.1.2'
   end
 end

--- a/spec/dummy/app/services/custom_failure_app.rb
+++ b/spec/dummy/app/services/custom_failure_app.rb
@@ -1,0 +1,7 @@
+class CustomFailureApp < Devise::FailureApp
+  # test that sublclassing FailureApp works properly
+  def respond
+    super
+    Rails.logger.info('Testing error flow')
+  end
+end

--- a/spec/dummy/config/initializers/devise.rb
+++ b/spec/dummy/config/initializers/devise.rb
@@ -244,6 +244,9 @@ Devise.setup do |config|
   #   manager.intercept_401 = false
   #   manager.default_strategies(scope: :user).unshift :some_external_strategy
   # end
+  config.warden do |manager|
+    manager.failure_app = CustomFailureApp
+  end
 
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine

--- a/spec/requests/oauth/bearer_tokens_spec.rb
+++ b/spec/requests/oauth/bearer_tokens_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'OAuth bearer token requests', type: :request do
       get request_path, params, headers
     end
     it { expect(response.status).to eq 401 }
-    it { expect(response.headers).to include('WWW-Authenticate' => 'Bearer realm="DeviseDoorkeeperApp", error="invalid_token", error_description="The access token is invalid"') }
+    it { expect(response.headers['WWW-Authenticate']).to eq 'Bearer realm="DeviseDoorkeeperApp", error="invalid_token", error_description="The access token is invalid"' }
     it { expect(response.body).to eq '{"error":"invalid_token","error_description":"The access token is invalid","state":"unauthorized"}' }
   end
   context 'with revoked access token' do

--- a/spec/requests/oauth/bearer_tokens_spec.rb
+++ b/spec/requests/oauth/bearer_tokens_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe 'OAuth bearer token requests', type: :request do
     end
     it { expect(response.status).to eq 401 }
     it { expect(response.headers).to include('WWW-Authenticate' => 'Bearer realm="DeviseDoorkeeperApp", error="invalid_token", error_description="The access token is invalid"') }
+    it { expect(response.body).to eq '{"error":"invalid_token","error_description":"The access token is invalid","state":"unauthorized"}' }
   end
   context 'with revoked access token' do
     with :access_token, revoked_at: 1.year.ago


### PR DESCRIPTION
* Inject doorkeeper error handling into base devise FailureApp

Fixes #9

Instead of using a custom subclass for doorkeeper failures, inject the
functionality into the base devise failure app.  This allows for
applications to implement their own custom FailureApp subclass without
breaking the doorkeeper error headers.