### PR TITLE
do not check for default scopes

### DIFF
--- a/lib/devise/strategies/doorkeeper.rb
+++ b/lib/devise/strategies/doorkeeper.rb
@@ -43,8 +43,7 @@ module Devise
 
       def resource_from_token
         token = ::Doorkeeper.authenticate(request)
-        scopes = ::Doorkeeper.configuration.default_scopes
-        invalid_token unless token && token.acceptable?(scopes)
+        invalid_token unless token && token.acceptable?([])
         mapping.to.find(token.resource_owner_id)
       end
 


### PR DESCRIPTION
Do not pass `::Doorkeeper.configuration.default_scopes` in `token.acceptable?`.

This logic is completely broken when `::Doorkeeper.configuration.default_scopes != []`.
`default_scopes` are scopes that applied to the token when application owner did not provide any desired scopes.
But when application DID provide desired scopes, then these scopes could not match with `default_scopes` and thus authentication fails.