### PR TITLE
Add a different response for unconfirmed resource access

### DIFF
--- a/devise-doorkeeper.gemspec
+++ b/devise-doorkeeper.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rails', '~> 5.0.0'
-  spec.add_dependency 'devise', '~> 4.7'
-  spec.add_dependency 'doorkeeper', '~> 5.5'
+  spec.add_dependency 'rails'
+  spec.add_dependency 'devise'
+  spec.add_dependency 'doorkeeper'
 
   spec.add_development_dependency 'bundler', '~> 2.2'
   spec.add_development_dependency 'rspec-rails', '~> 4.0'

--- a/lib/devise/doorkeeper/doorkeeper_failure_app.rb
+++ b/lib/devise/doorkeeper/doorkeeper_failure_app.rb
@@ -1,4 +1,5 @@
 require 'devise/strategies/doorkeeper'
+require 'devise/doorkeeper/unconfirmed_resource_response'
 
 module Devise
   module Doorkeeper
@@ -6,6 +7,8 @@ module Devise
       def respond
         if oauth_error?
           invalid_oauth_token
+        elsif unconfirmed_resource?
+          unconfirmed_resource
         else
           super
         end
@@ -17,8 +20,19 @@ module Devise
         warden_message == Devise::Strategies::Doorkeeper::WARDEN_INVALID_TOKEN_MESSAGE
       end
 
+      def unconfirmed_resource?
+        warden_message == Devise::Strategies::Doorkeeper::WARDEN_UNCONFIRMED_RESOURCE_MESSAGE
+      end
+
       def invalid_oauth_token
         error = ::Doorkeeper::OAuth::InvalidTokenResponse.new
+        headers.merge! error.headers
+        self.response_body = error.body.to_json
+        self.status = error.status
+      end
+
+      def unconfirmed_resource
+        error = UnconfirmedResourceResponse.new
         headers.merge! error.headers
         self.response_body = error.body.to_json
         self.status = error.status

--- a/lib/devise/doorkeeper/unconfirmed_resource_response.rb
+++ b/lib/devise/doorkeeper/unconfirmed_resource_response.rb
@@ -1,0 +1,19 @@
+require 'devise/strategies/doorkeeper'
+
+module Devise
+  module Doorkeeper
+    class UnconfirmedResourceResponse < ::Doorkeeper::OAuth::ErrorResponse
+      def initialize(attributes = {})
+        super(attributes.merge(name: :unconfirmed_resource, state: :locked))
+      end
+
+      def status
+        :locked
+      end
+
+      def exception_class
+        ::Doorkeeper::Errors::DoorkeeperError
+      end
+    end
+  end
+end

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -2,6 +2,10 @@ class User < ActiveRecord::Base
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable
+         :recoverable, :rememberable, :trackable, :validatable, :confirmable
   devise :database_authenticatable, :doorkeeper
+
+  def send_confirmation_notification?
+    false
+  end
 end

--- a/spec/dummy/db/migrate/20210301204550_add_confirmable_field_to_users.rb
+++ b/spec/dummy/db/migrate/20210301204550_add_confirmable_field_to_users.rb
@@ -1,0 +1,11 @@
+class AddConfirmableFieldToUsers < ActiveRecord::Migration[5.0]
+  def change
+    change_table(:users) do |t|
+      ## Confirmable
+      t.string   :confirmation_token
+      t.datetime :confirmed_at
+      t.datetime :confirmation_sent_at
+      t.string   :unconfirmed_email # Only if using reconfirmable
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210301163315) do
+ActiveRecord::Schema.define(version: 20210301204550) do
 
   create_table "oauth_access_grants", force: :cascade do |t|
     t.integer  "resource_owner_id", null: false
@@ -63,6 +63,10 @@ ActiveRecord::Schema.define(version: 20210301163315) do
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
     t.string   "last_sign_in_ip"
+    t.string   "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string   "unconfirmed_email"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,5 +4,10 @@ FactoryBot.define do
   factory :user do
     email { Faker::Internet.email }
     password { Faker::Internet.password }
+    confirmed_at { Time.current }
+
+    trait :when_unconfirmed do
+      confirmed_at { nil }
+    end
   end
 end

--- a/spec/requests/oauth/bearer_tokens_spec.rb
+++ b/spec/requests/oauth/bearer_tokens_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'OAuth bearer token requests', type: :request do
     end
     let(:params) { {} }
     before do
-      get request_path, params, headers
+      get request_path, params: params, headers: headers
     end
     it { expect(response.status).to eq 401 }
   end
@@ -75,7 +75,7 @@ RSpec.describe 'OAuth bearer token requests', type: :request do
     end
     let(:params) { {} }
     before do
-      get request_path, params, headers
+      get request_path, params: params, headers: headers
     end
     it { expect(response.status).to eq 401 }
   end

--- a/spec/requests/oauth/bearer_tokens_spec.rb
+++ b/spec/requests/oauth/bearer_tokens_spec.rb
@@ -3,28 +3,43 @@ require 'rails_helper'
 RSpec.describe 'OAuth bearer token requests', type: :request do
   let(:request_path) { '/example.json' }
   context 'with valid access token' do
-    with :access_token
-    let(:headers) do
-      {
-        'Authorization' => "Bearer #{access_token.token}"
-      }
+    context 'when user confirmed' do
+      let(:access_token) { create(:access_token) }
+      let(:headers) do
+        {
+          'Authorization' => "Bearer #{access_token.token}"
+        }
+      end
+      let(:params) { {} }
+      before do
+        @original_timestamp = User.find(access_token.resource_owner_id).last_sign_in_at
+        get request_path, params: params, headers: headers
+      end
+      it { expect(response.status).to eq 200 }
+      it 'does not send Set-Cookie headers' do
+        expect(response.headers).to_not include 'Set-Cookie'
+      end
+      it 'does not update the user last_signin_at timestamp' do
+        new_timestamp = User.find(access_token.resource_owner_id).last_sign_in_at
+        expect(new_timestamp).to eq @original_timestamp
+      end
     end
-    let(:params) { {} }
-    before do
-      @original_timestamp = User.find(access_token.resource_owner_id).last_sign_in_at
-      get request_path, params, headers
-    end
-    it { expect(response.status).to eq 200 }
-    it 'does not send Set-Cookie headers' do
-      expect(response.headers).to_not include 'Set-Cookie'
-    end
-    it 'does not update the user last_signin_at timestamp' do
-      new_timestamp = User.find(access_token.resource_owner_id).last_sign_in_at
-      expect(new_timestamp).to eq @original_timestamp
+    context 'when user unconfirmed' do
+      let(:user) { create(:user, :when_unconfirmed) }
+      let(:access_token) { create(:access_token, resource_owner_id: user.id) }
+      let(:headers) do
+        {
+          'Authorization' => "Bearer #{access_token.token}"
+        }
+      end
+      before do
+        get request_path, headers: headers
+      end
+      it { expect(response.status).to eq 423 }
     end
   end
   context 'with expired access token' do
-    with :access_token, expires_in: 0
+    let(:access_token) { create(:access_token, expires_in: 0) }
     let(:headers) do
       {
         'Authorization' => "Bearer #{access_token.token}"
@@ -32,14 +47,14 @@ RSpec.describe 'OAuth bearer token requests', type: :request do
     end
     let(:params) { {} }
     before do
-      get request_path, params, headers
+      get request_path, params: params, headers: headers
     end
     it { expect(response.status).to eq 401 }
     it { expect(response.headers['WWW-Authenticate']).to eq 'Bearer realm="DeviseDoorkeeperApp", error="invalid_token", error_description="The access token is invalid"' }
     it { expect(response.body).to eq '{"error":"invalid_token","error_description":"The access token is invalid","state":"unauthorized"}' }
   end
   context 'with revoked access token' do
-    with :access_token, revoked_at: 1.year.ago
+    let(:access_token) { create(:access_token, revoked_at: 1.year.ago) }
     let(:headers) do
       {
         'Authorization' => "Bearer #{access_token.token}"

--- a/spec/requests/oauth/password_grant_spec.rb
+++ b/spec/requests/oauth/password_grant_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'oauth/tokens password grant flow', type: :request do
       }.to_json
     end
     before do
-      post '/oauth/token', params, headers
+      post '/oauth/token', params: params, headers: headers
       @new_token = Doorkeeper::AccessToken.last
     end
     it { expect(response.status).to eq 200 }
@@ -43,7 +43,7 @@ RSpec.describe 'oauth/tokens password grant flow', type: :request do
     end
     let(:headers) { {} }
     before do
-      post '/oauth/token', params, headers
+      post '/oauth/token', params: params, headers: headers
     end
     it { expect(response.status).to eq 400 }
   end
@@ -61,7 +61,7 @@ RSpec.describe 'oauth/tokens password grant flow', type: :request do
     end
     let(:headers) { {} }
     before do
-      post '/oauth/token', params, headers
+      post '/oauth/token', params: params, headers: headers
     end
     it { expect(response.status).to eq 400 }
   end


### PR DESCRIPTION
For mobile registration/confirmation/authentication process, there's a state where the mobile app needs to know if a user has confirmed it's account or not. In order to do that, but in an authenticated way, we need to differentiate the error type from the usual `:unauthenticated` 401 we would receive if the let Devise and Warden to follow through with the authentication process.

Context:

Slack discussions:
- https://betterup.slack.com/archives/CGKHB55FT/p1614288395018600
- https://betterup.slack.com/archives/CGKHB55FT/p1614353863038500

Mobile Signup/Confirmation/Authentication flow RFC:
- https://betterup.atlassian.net/wiki/spaces/ET/pages/1766654135/API+Registration+Authentication+Flows

Disclaimers:
- I haven't written tests yet. I want to validate the approach before spending more time on it.
- I'm open for other status codes if you think 423 is not the best. I browsed through the 4XX and couldn't find a better candidate TBH.
