### PR TITLE
Add unconfirmed resource response description

### DIFF
--- a/lib/devise/doorkeeper/unconfirmed_resource_response.rb
+++ b/lib/devise/doorkeeper/unconfirmed_resource_response.rb
@@ -11,6 +11,10 @@ module Devise
         :locked
       end
 
+      def description
+        @description ||= I18n.translate('doorkeeper.errors.messages.unconfirmed_resource')
+      end
+
       def exception_class
         ::Doorkeeper::Errors::DoorkeeperError
       end

--- a/lib/devise/doorkeeper/version.rb
+++ b/lib/devise/doorkeeper/version.rb
@@ -1,5 +1,5 @@
 module Devise
   module Doorkeeper
-    VERSION = '1.1.2'
+    VERSION = '1.2.0'
   end
 end

--- a/spec/dummy/config/locales/doorkeeper.en.yml
+++ b/spec/dummy/config/locales/doorkeeper.en.yml
@@ -130,6 +130,8 @@ en:
           expired: "The access token expired"
           unknown: "The access token is invalid"
 
+        unconfirmed_resource: 'The resource owner account is unconfirmed.'
+
     flash:
       applications:
         create:

--- a/spec/requests/oauth/bearer_tokens_spec.rb
+++ b/spec/requests/oauth/bearer_tokens_spec.rb
@@ -36,6 +36,13 @@ RSpec.describe 'OAuth bearer token requests', type: :request do
         get request_path, headers: headers
       end
       it { expect(response.status).to eq 423 }
+      it do
+        expect(JSON.parse(response.body)).to include(
+          'error' => 'unconfirmed_resource',
+          'error_description' => 'The resource owner account is unconfirmed.',
+          'state' => 'locked'
+        )
+      end
     end
   end
   context 'with expired access token' do


### PR DESCRIPTION
Small followup of https://github.com/betterup/devise-doorkeeper/pull/17 + bumping minor version given there's a change in behavior of the gem but no broken dependencies nor backwards compatibility issues.